### PR TITLE
Update README.org w/ pipe op in another language

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 Pipeline works like the pipe operator more common in functional programming
-languages, like Erlang.
+languages, like Elixir.
 
 This lib supports **sync** and **async** arguments.
 


### PR DESCRIPTION
Erlang has no 'pipe' operator, Elixir however does!